### PR TITLE
update for issue with test NoUnusedTemporaryVariablesLeftTest >> #testNoUnusedTemporaryVariablesLeft

### DIFF
--- a/src/Athens-SVG-PathConverter/ASConverter.class.st
+++ b/src/Athens-SVG-PathConverter/ASConverter.class.st
@@ -28,7 +28,7 @@ Conforming High-Quality SVG Viewers are required to use at least double-precisio
 Within the SVG DOM, a <number> is represented as a float or an SVGAnimatedNumber.
 "
 	
-	| result char sign esign pos int frac exponent |
+	| result sign esign pos int frac exponent |
 	
 	esign := sign := 1.
 	pos := stream position.

--- a/src/Athens-SVG-PathConverter/ASPathConverter.class.st
+++ b/src/Athens-SVG-PathConverter/ASPathConverter.class.st
@@ -323,7 +323,7 @@ ASPathConverter >> m [
 		If a moveto is followed by multiple pairs of coordinates, the subsequent pairs are treated as implicit lineto commands.
 	
 	"
-	| pt reset |
+	| pt |
 
 	pt := self readPoint.
 	pt ifNil: [ self error: 'a point expected following after M/m command'].

--- a/src/Athens-SVG-PathConverter/AthensCairoPathBuilder.extension.st
+++ b/src/Athens-SVG-PathConverter/AthensCairoPathBuilder.extension.st
@@ -27,9 +27,7 @@ AthensCairoPathBuilder >> ellipticalArc3: radii xrot: xAxisRotation large: large
 
 "	 self cwArcTo: pt angle: 45 degreesToRadians  "
 	
-	| rx ry x1 y1 x2 y2 dx2 dy2 phi cosAngle sinAngle arx ary coeff cx1 cy1 ux uy vx vy sign xPrime1 yPrime1 r  radical  startAngle  sweepAngle cx cy aPoint |
-	
-	
+	| rx ry x1 y1 x2 y2 dx2 dy2 phi cosAngle sinAngle arx ary coeff cx1 cy1 ux uy vx vy sign xPrime1 yPrime1 radical startAngle sweepAngle cx cy aPoint |
 	aPoint := lastControlPoint.
 	
 	rx := radii x.
@@ -105,9 +103,7 @@ AthensCairoPathBuilder >> ellipticalArc: radii xrot: xAxisRotation large: largeA
 
 "	 self cwArcTo: pt angle: 45 degreesToRadians  "
 	
-	| rx ry x1 y1 x2 y2 dx2 dy2 phi cosAngle sinAngle arx ary coeff cx1 cy1 ux uy vx vy sign xPrime1 yPrime1 r  radical  startAngle  sweepAngle cx cy aPoint lFlag swFlag isRelative aCenter |
-	
-	
+	| rx ry x1 y1 x2 y2 dx2 dy2 phi cosAngle sinAngle arx ary coeff cx1 cy1 ux uy vx vy sign xPrime1 yPrime1 radical startAngle sweepAngle cx cy aPoint lFlag swFlag isRelative aCenter |
 	aPoint := 0@0.
 	
 	lFlag := false.
@@ -193,7 +189,7 @@ AthensCairoPathBuilder >> ellipticalArc: radii xrot: xAxisRotation large: largeA
 
 "	 self cwArcTo: pt angle: 45 degreesToRadians  "
 	
-	| rx ry x1 y1 x2 y2 dx2 dy2 phi cosAngle sinAngle arx ary coeff cx1 cy1 ux uy vx vy sign xPrime1 yPrime1 r  radical  startAngle  sweepAngle cx cy aPoint lFlag swFlag aCenter uySign |
+	| rx ry x1 y1 x2 y2 dx2 dy2 arx ary coeff cx1 cy1 ux uy vx vy sign xPrime1 yPrime1 radical  startAngle sweepAngle cx cy aPoint lFlag swFlag aCenter uySign |
 	
 	
 	aPoint := isRelative


### PR DESCRIPTION
Update for NoUnusedTemporaryVariablesLeftTest >> #testNoUnusedTemporaryVariablesLeft
Because Roassal3 uses Athens-SVG