### PR TITLE
7 some svg files do not have xml declaration   fix image file format detection in svm read writer

### DIFF
--- a/src/Athens-SVG/SVGReadWriter.class.st
+++ b/src/Athens-SVG/SVGReadWriter.class.st
@@ -41,7 +41,7 @@ SVGReadWriter >> nextPutImage: imageForm [
 
 { #category : #private }
 SVGReadWriter >> on: aBinaryStream [
-	^super on: ZnCharacterReadStream 
+	^super on: (ZnCharacterReadStream on: aBinaryStream)
 ]
 
 { #category : #accessing }

--- a/src/Athens-SVG/SVGReadWriter.class.st
+++ b/src/Athens-SVG/SVGReadWriter.class.st
@@ -41,8 +41,12 @@ SVGReadWriter >> nextPutImage: imageForm [
 
 { #category : #accessing }
 SVGReadWriter >> understandsImageFormat [ 
-	| img |
-	img := self nextImage.
+	| str |
+	str := (stream next: 5) asString.
+	str = '<?xml' ifFalse: [ ^false ].
+"	str := stream upTo: $<.
+	str := (stream next: 3) asString.
+	str = 'svg' ifFalse: [ ^false ]."
 	^true
 	
 ]

--- a/src/Athens-SVG/SVGReadWriter.class.st
+++ b/src/Athens-SVG/SVGReadWriter.class.st
@@ -42,11 +42,10 @@ SVGReadWriter >> nextPutImage: imageForm [
 { #category : #accessing }
 SVGReadWriter >> understandsImageFormat [ 
 	| str |
-	str := (stream next: 5) asString.
-	str = '<?xml' ifFalse: [ ^false ].
-"	str := stream upTo: $<.
+	stream upTo: $<.
+	"Skip processing directives etc..."
+	[stream peek isLetter] whileFalse: [ stream upTo: $< ].
 	str := (stream next: 3) asString.
-	str = 'svg' ifFalse: [ ^false ]."
-	^true
-	
+	"Does the first element start with svg?"
+	^str = 'svg'
 ]

--- a/src/Athens-SVG/SVGReadWriter.class.st
+++ b/src/Athens-SVG/SVGReadWriter.class.st
@@ -39,6 +39,11 @@ SVGReadWriter >> nextPutImage: imageForm [
 	self error: 'Cannot convert bitmapped image to vector format.'
 ]
 
+{ #category : #private }
+SVGReadWriter >> on: aBinaryStream [
+	^super on: ZnCharacterReadStream 
+]
+
 { #category : #accessing }
 SVGReadWriter >> understandsImageFormat [ 
 	| str |

--- a/src/Athens-SVG/SVGReadWriter.class.st
+++ b/src/Athens-SVG/SVGReadWriter.class.st
@@ -42,7 +42,9 @@ SVGReadWriter >> nextPutImage: imageForm [
 { #category : #accessing }
 SVGReadWriter >> understandsImageFormat [ 
 	| str |
-	stream upTo: $<.
+	[stream peek isSeparator] whileTrue: [ stream next ].
+	stream peek = $< ifFalse: [ ^false ].
+	stream next.
 	"Skip processing directives etc..."
 	[stream peek isLetter] whileFalse: [ stream upTo: $< ].
 	str := (stream next: 3) asString.


### PR DESCRIPTION
This now works cleanly on every svg file I can find.

Some sloppy heuristics but they seem to work well.