### PR TITLE
Update ASPathConverter.class.st

### DIFF
--- a/src/Athens-SVG-PathConverter/ASPathConverter.class.st
+++ b/src/Athens-SVG-PathConverter/ASPathConverter.class.st
@@ -17,7 +17,6 @@ Class {
 	#name : #ASPathConverter,
 	#superclass : #ASConverter,
 	#instVars : [
-		'segments',
 		'path',
 		'absolute'
 	],


### PR DESCRIPTION
segments is not used and its detected by release tests of pharo, currently used by roassal